### PR TITLE
feat: digest-pinned template sync + auto version bump

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -13,8 +13,18 @@
 # Supply chain notes:
 #   - Templates are pulled from GitHub Release assets (not source files)
 #   - The compose file in release assets has digest-pinned images (@sha256:...)
-#   - package.json version is auto-bumped to match the release tag
+#   - package.json "platformVersion" tracks which syntropic release the templates are from
+#   - package.json "version" is always >= platformVersion (bumps patch on collision)
 #   - A CI consistency check validates version + digest pin alignment
+#
+# Versioning rules:
+#   - platformVersion = the syntropic release these templates came from
+#   - version = npm publish version (may drift ahead due to npx-only changes)
+#   - version >= platformVersion, always
+#   - If platformVersion > version: version resets to platformVersion
+#   - If platformVersion == version: version bumps patch (collision avoidance)
+#   - If platformVersion < version (same major.minor): version bumps patch, platformVersion updates
+#   - If platformVersion bumps major.minor: version resets to platformVersion
 
 name: Template Sync
 
@@ -47,9 +57,9 @@ jobs:
         run: |
           REF="${{ inputs.ref || 'main' }}"
           # Strip leading 'v' for npm version
-          VERSION="${REF#v}"
+          PLATFORM_VERSION="${REF#v}"
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "platform_version=$PLATFORM_VERSION" >> "$GITHUB_OUTPUT"
           echo "is_release=$( [[ "$REF" == v* ]] && echo true || echo false )" >> "$GITHUB_OUTPUT"
 
       # Download digest-pinned compose + selfhost files from release assets.
@@ -106,12 +116,53 @@ jobs:
         run: |
           cp _upstream/docker/init-db/01-create-databases.sql templates/init-db/
 
-      # Bump package.json + package-lock.json to match the release version
+      # Smart version bump:
+      #   - Sets platformVersion to the syntropic release
+      #   - Bumps npm version to max(current, platformVersion)
+      #   - On collision (current == platformVersion), bumps patch
       - name: Bump version
         if: steps.version.outputs.is_release == 'true'
         run: |
-          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
-          echo "✅ Bumped package version to ${{ steps.version.outputs.version }}"
+          PLATFORM="${{ steps.version.outputs.platform_version }}"
+          CURRENT=$(node -p "require('./package.json').version")
+
+          # Parse major.minor.patch
+          IFS='.' read -r P_MAJOR P_MINOR P_PATCH <<< "$PLATFORM"
+          IFS='.' read -r C_MAJOR C_MINOR C_PATCH <<< "$CURRENT"
+
+          # Determine the right npm version
+          if [[ "$P_MAJOR" -gt "$C_MAJOR" ]] || \
+             { [[ "$P_MAJOR" -eq "$C_MAJOR" ]] && [[ "$P_MINOR" -gt "$C_MINOR" ]]; }; then
+            # Platform bumped major or minor — reset to platform version
+            NEW_VERSION="$PLATFORM"
+          elif [[ "$PLATFORM" == "$CURRENT" ]]; then
+            # Collision — same version, bump patch
+            NEW_VERSION="${C_MAJOR}.${C_MINOR}.$((C_PATCH + 1))"
+          elif [[ "$P_MAJOR" -eq "$C_MAJOR" ]] && [[ "$P_MINOR" -eq "$C_MINOR" ]] && \
+               [[ "$P_PATCH" -gt "$C_PATCH" ]]; then
+            # Platform patch is ahead — reset to platform version
+            NEW_VERSION="$PLATFORM"
+          else
+            # Current is ahead of platform (npx-only patches) — bump patch
+            NEW_VERSION="${C_MAJOR}.${C_MINOR}.$((C_PATCH + 1))"
+          fi
+
+          # Update platformVersion in package.json
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.syntropic137 = pkg.syntropic137 || {};
+            pkg.syntropic137.platformVersion = '${PLATFORM}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          # Bump npm version (updates both package.json and package-lock.json)
+          npm version "$NEW_VERSION" --no-git-tag-version
+
+          echo "📦 Platform version: $PLATFORM"
+          echo "📦 Previous npm version: $CURRENT"
+          echo "📦 New npm version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Validate digest pins
         if: steps.version.outputs.is_release == 'true'
@@ -143,7 +194,7 @@ jobs:
             Automated template sync from `syntropic137/syntropic137`.
 
             **Source ref:** `${{ steps.version.outputs.ref }}`
-            **Package version:** `${{ steps.version.outputs.version }}`
+            **Platform version:** `${{ steps.version.outputs.platform_version }}`
             **Digest-pinned:** ${{ steps.version.outputs.is_release == 'true' && '✅ Yes (from release assets)' || '⚠️ No (source checkout — floating tags)' }}
 
             Review the diff carefully before merging. See [SECURITY.md](./SECURITY.md) for context.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "type": "git",
     "url": "git+https://github.com/syntropic137/syntropic137-npx.git"
   },
+  "syntropic137": {
+    "platformVersion": "0.18.2"
+  },
   "license": "MIT",
   "devDependencies": {
     "typescript": "^5.5.0",


### PR DESCRIPTION
## Summary

Hardens the template-sync pipeline for supply chain integrity:

1. **Digest-pinned compose files** — downloads from GitHub Release assets (`@sha256:...` image refs) instead of source files (`:latest` floating tags)
2. **Auto version bump** — `package.json` + `package-lock.json` bumped to match the release tag
3. **Digest validation** — fails if any GHCR image uses a floating tag instead of a digest pin
4. **Non-release fallback** — manual syncs from `main` still work (source checkout, with a warning in the PR body)

### Before
- Templates copied from source → images use `${SYN_VERSION:-latest}`
- Version stays at whatever was in `package.json`
- No validation

### After
- Release syncs download digest-pinned assets → images use `@sha256:abc123...`
- Version auto-bumped to match release tag
- Validation step rejects floating tags
- PR body clearly shows whether templates are pinned or floating

## Test plan
- [ ] Trigger manually: `gh workflow run template-sync.yml --repo syntropic137/syntropic137-npx --field ref=v0.19.0`
- [ ] Verify compose file has `@sha256:` image refs (not `:latest`)
- [ ] Verify `package.json` version matches release tag
- [ ] Verify non-release fallback: `gh workflow run template-sync.yml --repo syntropic137/syntropic137-npx --field ref=main`

Partial fix for #7 (CI consistency check is a separate PR).