### PR TITLE
feat: add post-merge publish checklist to sync PR body

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -198,6 +198,14 @@ jobs:
             **Digest-pinned:** ${{ steps.version.outputs.is_release == 'true' && '✅ Yes (from release assets)' || '⚠️ No (source checkout — floating tags)' }}
 
             Review the diff carefully before merging. See [SECURITY.md](./SECURITY.md) for context.
+
+            ---
+
+            ## Post-merge checklist
+
+            - [ ] Review diff — templates, version bump, digest pins
+            - [ ] Merge this PR
+            - [ ] [**Trigger publish →**](https://github.com/syntropic137/syntropic137-npx/actions/workflows/publish.yml) (Actions → "Publish to npm" → Run workflow)
           commit-message: "chore: sync templates from syntropic137/syntropic137 (${{ steps.version.outputs.ref }})"
           labels: templates, automated
 


### PR DESCRIPTION
## Summary
Adds a post-merge checklist to the auto-generated template sync PR body with a direct link to the publish workflow.

When template sync opens a PR, it now includes:
- [ ] Review diff
- [ ] Merge this PR  
- [ ] [**Trigger publish →**](link) 

So you don't have to hunt for the publish action after merging.