### PR TITLE
fix: rename checklist header and use dynamic URL in sync PR body

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -202,11 +202,11 @@ jobs:
 
             ---
 
-            ## Post-merge checklist
+            ## Checklist
 
             - [ ] Review diff — templates, version bump, digest pins
             - [ ] Merge this PR
-            - [ ] [**Trigger publish →**](https://github.com/syntropic137/syntropic137-npx/actions/workflows/publish.yml) (Actions → "Publish to npm" → Run workflow)
+            - [ ] [**Trigger publish →**](${{ github.server_url }}/${{ github.repository }}/actions/workflows/publish.yml) (Actions → "Publish to npm" → Run workflow)
           commit-message: "chore: sync templates from syntropic137/syntropic137 (${{ steps.version.outputs.ref }})"
           labels: templates, automated
 


### PR DESCRIPTION
## Summary
Addresses Copilot review comments from #10:
- Rename "Post-merge checklist" to "Checklist" since the list includes pre-merge steps
- Use `github.server_url`/`github.repository` instead of hardcoded URL so the publish link works in forks and GHE

## Test plan
- [ ] Trigger a manual template sync and verify the PR body renders correctly