### PR TITLE
fix: add installation and installation_repositories to manifest events

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ When you don't pass `--skip-github`, the CLI creates a GitHub App automatically.
 6. Credentials are saved to `~/.syntropic137/secrets/` with chmod 600
 7. Your browser opens the app's installation page so you can choose which repos to grant access
 
-The private key (PEM) is mounted into containers as a Docker secret (tmpfs-backed, never written to the container filesystem). Installation IDs are resolved dynamically at runtime, so the app can be installed across multiple orgs and repos.
+The private key (PEM) is mounted into containers as a Docker secret (tmpfs-backed, never written to the container filesystem). Installation IDs are resolved dynamically at runtime, so the app can be installed across multiple orgs and repos. Repositories granted to the installation are discovered automatically at startup and refreshed every hour without requiring a webhook URL.
 
 ## What gets installed
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -23,6 +23,8 @@ const DEFAULT_PERMISSIONS: AppPermissions = {
 };
 
 const DEFAULT_EVENTS: string[] = [
+  "installation",
+  "installation_repositories",
   "workflow_run",
   "workflow_job",
   "check_run",


### PR DESCRIPTION
## Problem

`installation` and `installation_repositories` events were missing from `DEFAULT_EVENTS` in the manifest builder. GitHub App installations created via the manifest flow never subscribed to installation lifecycle events, even when a webhook URL was provided.

## Solution

Add both events to `DEFAULT_EVENTS`. They only take effect when `webhookUrl` is set (the existing `if (opts.webhookUrl)` guard), so the no-webhook path is unaffected.

Also document in README that repositories are discovered automatically at startup and refreshed hourly without requiring a webhook URL (the platform-side fix handles this).

## Milestone

Assign to milestone "🚀 Open Source Launch" (milestone #2 on syntropic137/syntropic137-npx).