### PR TITLE
test: assert installation events in manifest test coverage

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -42,6 +42,8 @@ describe("buildManifest", () => {
     expect(events).toContain("pull_request");
     expect(events).toContain("push");
     expect(events).toContain("issues");
+    expect(events).toContain("installation");
+    expect(events).toContain("installation_repositories");
 
     const hook = manifest.hook_attributes as Record<string, unknown>;
     expect(hook.url).toBe("https://example.com/webhook");


### PR DESCRIPTION
Addresses Copilot review comment on #50: the new `installation` and `installation_repositories` events added to `DEFAULT_EVENTS` were not covered by test assertions. Extends the existing `webhookUrl` test to assert both events are present, preventing future regressions.