### PR TITLE
fix: setup hardening — install dir, menu UX, credential rotation safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Everything lives in `~/.syntropic137/`:
 ├── selfhost-entrypoint.sh             # Secret injection at container startup
 ├── selfhost.env.example               # Reference template
 ├── .env                               # Your configuration (chmod 600)
-├── .env.backup                        # Pre-rotation backup, created by credentials rollback
+├── .env.backup                        # Pre-rotation backup, consumed by credentials rollback (written by rotation once re-enabled)
 ├── init-db/
 │   └── 01-create-databases.sql        # Database schema
 ├── secrets/

--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ npx @syntropic137/setup init [options]
 After initial setup, manage your stack with:
 
 ```sh
-npx @syntropic137/setup status    # Container health (docker compose ps)
-npx @syntropic137/setup stop      # Stop the stack
-npx @syntropic137/setup start     # Start the stack
-npx @syntropic137/setup logs      # Tail container logs
-npx @syntropic137/setup update    # Pull latest images and restart
+npx @syntropic137/setup status       # Container health (docker compose ps)
+npx @syntropic137/setup stop         # Stop the stack
+npx @syntropic137/setup start        # Start the stack
+npx @syntropic137/setup logs         # Tail container logs
+npx @syntropic137/setup update       # Pull latest images and restart
+npx @syntropic137/setup credentials  # View gateway credentials (show / rollback)
 ```
 
-All commands accept `--dir <path>` if your install directory isn't the default.
+All commands accept `--dir <path>` if your install directory isn't the default `~/.syntropic137`.
 
 ## How the GitHub App Manifest flow works
 
@@ -78,6 +79,7 @@ Everything lives in `~/.syntropic137/`:
 ├── selfhost-entrypoint.sh             # Secret injection at container startup
 ├── selfhost.env.example               # Reference template
 ├── .env                               # Your configuration (chmod 600)
+├── .env.backup                        # Pre-rotation backup, created by credentials rollback
 ├── init-db/
 │   └── 01-create-databases.sql        # Database schema
 ├── secrets/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ export class InitFlow {
   private readonly secrets: SecretsManager;
 
   constructor(private readonly opts: CliOptions) {
-    this.installDir = opts.dir || DEFAULT_INSTALL_DIR;
+    this.installDir = path.resolve(opts.dir || DEFAULT_INSTALL_DIR);
     this.secretsDir = path.join(this.installDir, "secrets");
     this.appName = opts.name || DEFAULT_APP_NAME;
     this.config = new ConfigManager(this.installDir);
@@ -167,6 +167,7 @@ export class InitFlow {
     const envValues: EnvValues = {
       [ENV_KEYS.APP_ENVIRONMENT]: DEFAULT_APP_ENVIRONMENT,
       [ENV_KEYS.SYN_VERSION]: PLATFORM_VERSION,
+      [ENV_KEYS.SYN_INSTALL_DIR]: this.installDir,
       [ENV_KEYS.SYN_API_USER]: DEFAULT_API_USER,
       [ENV_KEYS.SYN_API_PASSWORD]: apiPassword,
     };
@@ -687,16 +688,16 @@ export class CLI {
 
   // ── Credentials management ───────────────────────────────────────────
 
-  private async credentials(dir: string, action?: "show" | "rotate"): Promise<void> {
+  private async credentials(dir: string, action?: "show" | "rotate" | "rollback"): Promise<void> {
     const installDir = this.resolveDir(dir);
 
     // If no action provided, show a sub-menu
     if (!action) {
       const items: MenuItem[] = [
-        { label: "show",   value: "show",   description: "View access instructions and copy commands" },
-        { label: "rotate", value: "rotate", description: "Regenerate all secrets and restart the stack" },
+        { label: "show",     value: "show",     description: "View access instructions and copy commands" },
+        { label: "rollback", value: "rollback", description: "Restore credentials from the last backup" },
       ];
-      action = (await interactiveMenu(items, "What would you like to do?")) as "show" | "rotate";
+      action = (await interactiveMenu(items, "What would you like to do?")) as "show" | "rollback";
       console.log();
     }
 
@@ -705,49 +706,62 @@ export class CLI {
       return;
     }
 
-    // ── rotate ──────────────────────────────────────────────────────────
+    if (action === "rollback") {
+      await this.credentialsRollback(installDir);
+      return;
+    }
+
+    // ── rotate: temporarily disabled (phase 2 tracked in issue #56) ─────
+    // Rotation updates .env and secret files but the event store password is
+    // baked in at container init time — after a stack restart the event store
+    // can no longer authenticate to the database, breaking the system with no
+    // safe recovery path. Re-enable once service-aware two-phase rotation is
+    // implemented. See: https://github.com/syntropic137/syntropic137-npx/issues/56
     console.log();
-    info(bold("Credential Rotation"));
+    warn("Credential rotation is temporarily disabled.");
+    info("Track progress: https://github.com/syntropic137/syntropic137-npx/issues/56");
     console.log();
-    info("This will regenerate all secrets and restart the stack.");
-    info("Active browser sessions and CLI sessions will need to re-authenticate.");
+  }
+
+  /**
+   * Restore credentials from the last pre-rotation backup.
+   *
+   * The backup is written to .env.backup before any rotation step, so this
+   * command returns the stack to its last known-good credential state.
+   */
+  private async credentialsRollback(installDir: string): Promise<void> {
+    const backupPath = path.join(installDir, ".env.backup");
+
+    if (!fs.existsSync(backupPath)) {
+      fail("No credential backup found.");
+      info(`Expected: ${backupPath}`);
+      info("A backup is created automatically before each rotation. If none exists,");
+      info("credentials have not been rotated via this tool.");
+      return;
+    }
+
+    console.log();
+    info(bold("Credential Rollback"));
+    console.log();
+    info(`Backup: ${dim(backupPath)}`);
+    info("This will restore the previous .env and restart the stack.");
     console.log();
 
-    const proceed = await confirm("Rotate credentials now?", false);
+    const proceed = await confirm("Restore previous credentials?", false);
     if (!proceed) {
       info("Cancelled.");
       return;
     }
 
-    const secrets = new SecretsManager(path.join(installDir, "secrets"));
-    const config = new ConfigManager(installDir);
+    fs.copyFileSync(backupPath, path.join(installDir, ".env"));
+    fs.chmodSync(path.join(installDir, ".env"), 0o600);
 
-    // Step 1: Rotate infra secrets (db, redis, minio) — backs up old to .bak
-    info("Rotating infrastructure secrets...");
-    secrets.generate(true);
-
-    // Step 2: Generate new gateway auth password
-    // Do not wrap: if crypto fails, propagate immediately.
-    const newPassword = crypto.randomBytes(32).toString("hex");
-
-    // Step 3: Update .env with the new password
-    const env = config.readEnv();
-    env[ENV_KEYS.SYN_API_PASSWORD] = newPassword;
-    env[ENV_KEYS.SYN_API_USER] = env[ENV_KEYS.SYN_API_USER] || DEFAULT_API_USER;
-    config.writeEnv(env as EnvValues, TEMPLATES_DIR);
-
-    // Step 4: Restart stack — explicit stop then start (not `up -d`) to ensure
-    // all containers reload with new secrets. Between writeEnv and docker.start(),
-    // the running stack still accepts the old password (nginx htpasswd loaded at
-    // startup). The window closes when docker.start() completes.
-    info("Restarting the stack with new credentials...");
+    info("Restarting the stack with restored credentials...");
     const docker = new DockerService(installDir);
     docker.stop();
     docker.start();
 
-    success("Credentials rotated successfully");
-    console.log();
-    info(`${dim("Note: previous secrets backed up to")} ${dim(path.join(installDir, "secrets") + "/*.bak")} ${dim("— delete if no longer needed.")}`);
+    success("Credentials restored from backup");
     console.log();
     this.credentialsShow(installDir);
   }
@@ -776,7 +790,7 @@ export class CLI {
     info(`    ${dim(`export ${ENV_KEYS.SYN_API_USER}=${username}`)}`);
     info(`    ${dim(`export ${ENV_KEYS.SYN_API_PASSWORD}=$(grep ${ENV_KEYS.SYN_API_PASSWORD} ${quotedEnvPath} | cut -d= -f2)`)}`);
     console.log();
-    info(`  Rotate: ${cyan(`${BIN} credentials rotate`)}`);
+    info(`  Roll back a rotation: ${cyan(`${BIN} credentials rollback`)}`);
     console.log();
   }
 
@@ -787,11 +801,28 @@ export class CLI {
     // Flair target = subtitle line in banner. From the save point (after title+blank),
     // count up: blank(1) + title(1) + blank-after-banner(1) + bottom-border(1) + url(1) + subtitle(1) = 6
     const flairLinesAboveSave = 6;
-    const menuItems: MenuItem[] = COMMANDS.map((c) => ({
-      label: c.name,
-      value: c.name,
-      description: c.description,
-    }));
+
+    const installDir = path.resolve(this.opts.dir || DEFAULT_INSTALL_DIR);
+    const initDone = fs.existsSync(installDir);
+
+    // Commands that require a completed init (install dir must exist)
+    const requiresInit = new Set([
+      "status", "stop", "start", "logs", "update",
+      "credentials", "tunnel", "github-app",
+    ]);
+
+    const menuItems: MenuItem[] = COMMANDS.map((c) => {
+      const needsInit = requiresInit.has(c.name);
+      const disabled = needsInit && !initDone;
+      return {
+        label: c.name,
+        value: c.name,
+        description: c.description,
+        disabled,
+        disabledReason: disabled ? `run ${CMD.init} first` : undefined,
+      };
+    });
+
     const choice = await interactiveMenu(
       menuItems,
       "What would you like to do?",
@@ -833,7 +864,7 @@ export class CLI {
     // Parse sub-action for `credentials` command
     if (command === "credentials" && args[1]) {
       const secondArg = args[1];
-      if (secondArg === "show" || secondArg === "rotate") {
+      if (secondArg === "show" || secondArg === "rotate" || secondArg === "rollback") {
         opts.credentialsAction = secondArg;
       }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -803,7 +803,7 @@ export class CLI {
     const flairLinesAboveSave = 6;
 
     const installDir = path.resolve(this.opts.dir || DEFAULT_INSTALL_DIR);
-    const initDone = fs.existsSync(installDir);
+    const initDone = new ConfigManager(installDir).exists();
 
     // Commands that require a completed init (install dir must exist)
     const requiresInit = new Set([

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const ENV_KEYS = {
   SYN_API_USER: "SYN_API_USER",
   SYN_GATEWAY_PORT: "SYN_GATEWAY_PORT",
   SYN_VERSION: "SYN_VERSION",
+  SYN_INSTALL_DIR: "SYN_INSTALL_DIR",
   APP_ENVIRONMENT: "APP_ENVIRONMENT",
   ANTHROPIC_API_KEY: "ANTHROPIC_API_KEY",
   CLAUDE_CODE_OAUTH_TOKEN: "CLAUDE_CODE_OAUTH_TOKEN",
@@ -67,7 +68,7 @@ export const COMMANDS: readonly CommandDef[] = [
   { name: "plugin",      description: "Install or update the Claude Code plugin" },
   { name: "github-app",  description: "Open GitHub App settings in your browser" },
   { name: "tunnel",      description: "Set up remote access (Cloudflare tunnel)" },
-  { name: "credentials", description: "View or rotate gateway credentials", args: "[show|rotate]" },
+  { name: "credentials", description: "View gateway credentials or roll back a rotation", args: "[show|rollback]" },
 ] as const;
 
 /** Shorthand lookup: CMD.init → "npx @syntropic137/setup init" */

--- a/src/init.integration.test.ts
+++ b/src/init.integration.test.ts
@@ -165,6 +165,26 @@ describe("runInit --skip-docker --skip-github", () => {
     const content = fs.readFileSync(path.join(tmpDir, ".env"), "utf-8");
     expect(content).toContain("APP_ENVIRONMENT=selfhost");
   });
+
+  it(".env contains SYN_INSTALL_DIR as an absolute path matching the install dir", async () => {
+    await runInit({ command: "init", dir: tmpDir, skipDocker: true, skipGithub: true });
+
+    const content = fs.readFileSync(path.join(tmpDir, ".env"), "utf-8");
+    const match = content.match(/^SYN_INSTALL_DIR=(.+)$/m);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe(path.resolve(tmpDir));
+    expect(path.isAbsolute(match![1]!)).toBe(true);
+  });
+
+  it("resolves a relative --dir to an absolute path in .env", async () => {
+    const relativeDir = path.relative(process.cwd(), tmpDir);
+    await runInit({ command: "init", dir: relativeDir, skipDocker: true, skipGithub: true });
+
+    const content = fs.readFileSync(path.join(tmpDir, ".env"), "utf-8");
+    const match = content.match(/^SYN_INSTALL_DIR=(.+)$/m);
+    expect(match).not.toBeNull();
+    expect(path.isAbsolute(match![1]!)).toBe(true);
+  });
 });
 
 describe("runInit with mocked GitHub flow", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 export interface CliOptions {
   command: "init" | "status" | "stop" | "start" | "logs" | "update" | "plugin" | "github-app" | "tunnel" | "cli" | "credentials" | "menu" | "help";
   /** Sub-action for the `credentials` command. */
-  credentialsAction?: "show" | "rotate";
+  credentialsAction?: "show" | "rotate" | "rollback";
   org?: string;
   name?: string;
   dir?: string;
@@ -15,6 +15,7 @@ export interface CliOptions {
 export interface EnvValues {
   APP_ENVIRONMENT: string;
   SYN_VERSION: string;
+  SYN_INSTALL_DIR?: string;
   SYN_API_USER?: string;
   SYN_API_PASSWORD?: string;
   ANTHROPIC_API_KEY?: string;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -184,6 +184,10 @@ export interface MenuItem {
   label: string;
   value: string;
   description: string;
+  /** When true the item is rendered dimmed and cannot be selected. */
+  disabled?: boolean;
+  /** Shown inline when the user tries to select a disabled item. */
+  disabledReason?: string;
 }
 
 // Entropy flair frames — subtle cycling diamond in the banner subtitle
@@ -211,19 +215,37 @@ export function interactiveMenu(
     let flairIdx = 0;
     let hasDrawn = false;
 
-    function renderItems() {
-      // On redraws, move cursor up to overwrite the previous menu
+    // Lines used by the inline error message (null when none shown)
+    let errorLines = 0;
+
+    function renderItems(errorMsg?: string) {
+      // On redraws, move cursor up to overwrite previous menu + any error
       if (hasDrawn) {
-        out.write(`\x1b[${items.length}A`);
+        out.write(`\x1b[${items.length + errorLines}A`);
       }
       out.write("\x1b[J"); // clear from cursor down
       hasDrawn = true;
+      errorLines = 0;
+
       for (let i = 0; i < items.length; i++) {
         const item = items[i]!;
-        const pointer = i === selected ? cyan("  ❯ ") : "    ";
-        const label = i === selected ? bold(item.label) : item.label;
-        const desc = dim(item.description);
-        out.write(`${pointer}${label}  ${desc}\n`);
+        if (item.disabled) {
+          const pointer = "    ";
+          const label = dim(item.label);
+          const desc = dim(item.description);
+          const lock = dim("✗");
+          out.write(`${pointer}${label}  ${desc}  ${lock}\n`);
+        } else {
+          const pointer = i === selected ? cyan("  ❯ ") : "    ";
+          const label = i === selected ? bold(item.label) : item.label;
+          const desc = dim(item.description);
+          out.write(`${pointer}${label}  ${desc}\n`);
+        }
+      }
+
+      if (errorMsg) {
+        out.write(`\n  ${red("  ✗")} ${errorMsg}\n`);
+        errorLines = 2;
       }
     }
 
@@ -259,16 +281,36 @@ export function interactiveMenu(
     stdin.resume();
     stdin.setEncoding("utf-8");
 
+    // Skip over disabled items when navigating
+    function nextEnabled(from: number, dir: 1 | -1): number {
+      let i = (from + dir + items.length) % items.length;
+      let attempts = 0;
+      while (items[i]!.disabled && attempts < items.length) {
+        i = (i + dir + items.length) % items.length;
+        attempts++;
+      }
+      return i;
+    }
+
+    // Start cursor on first enabled item
+    selected = nextEnabled(-1, 1);
+
     function onData(key: string) {
       if (key === "\x1b[A" || key === "k") {
-        selected = (selected - 1 + items.length) % items.length;
+        selected = nextEnabled(selected, -1);
         renderItems();
       } else if (key === "\x1b[B" || key === "j") {
-        selected = (selected + 1) % items.length;
+        selected = nextEnabled(selected, 1);
         renderItems();
       } else if (key === "\r" || key === "\n") {
-        cleanup();
-        resolve(items[selected]!.value);
+        const item = items[selected]!;
+        if (item.disabled) {
+          const reason = item.disabledReason ?? "not available";
+          renderItems(reason);
+        } else {
+          cleanup();
+          resolve(item.value);
+        }
       } else if (key === "\x03") {
         cleanup();
         process.exit(0);
@@ -419,7 +461,7 @@ export function summaryBox(opts: {
     console.log(boxLine(`    syn CLI access:`, width));
     console.log(boxLine(`      ${dim(`export ${ENV_KEYS.SYN_API_USER}=${username}`)}`, width));
     console.log(boxLine(`      ${dim(`export ${ENV_KEYS.SYN_API_PASSWORD}=$(grep ${ENV_KEYS.SYN_API_PASSWORD} ${envPath} | cut -d= -f2)`)}`, width));
-    console.log(boxLine(`    Rotate: ${cyan(`${BIN} credentials rotate`)}`, width));
+    console.log(boxLine(`    View: ${cyan(`${BIN} credentials show`)}`, width));
   }
 
   console.log(`  ${dim(BOX.bl + BOX.h.repeat(width + 2) + BOX.br)}`);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -215,7 +215,7 @@ export function interactiveMenu(
     let flairIdx = 0;
     let hasDrawn = false;
 
-    // Lines used by the inline error message (null when none shown)
+    // Lines used by the inline error message (0 when none shown)
     let errorLines = 0;
 
     function renderItems(errorMsg?: string) {
@@ -253,8 +253,10 @@ export function interactiveMenu(
       if (!flair || !isTTY) return;
       flairIdx++;
       const ch = FLAIR_FRAMES[flairIdx % FLAIR_FRAMES.length]!;
-      // Move up from current position to the flair line, update char, move back
-      const linesUp = items.length + flair.linesAboveSave;
+      // Move up from current position to the flair line, update char, move back.
+      // Include errorLines so the flair targets the correct line when an inline
+      // error banner is visible below the menu.
+      const linesUp = items.length + errorLines + flair.linesAboveSave;
       out.write(
         `\x1b[${linesUp}F` +      // move up N lines (to start of line)
         `\x1b[${flair.col}G` +    // move to column
@@ -268,6 +270,20 @@ export function interactiveMenu(
       out.write(`  ${bold(title)}\n\n`);
     }
 
+    // Start cursor on first enabled item before the initial render so the
+    // pointer appears correctly on the first draw.
+    function nextEnabled(from: number, dir: 1 | -1): number {
+      let i = (from + dir + items.length) % items.length;
+      let attempts = 0;
+      while (items[i]!.disabled && attempts < items.length) {
+        i = (i + dir + items.length) % items.length;
+        attempts++;
+      }
+      return i;
+    }
+
+    selected = nextEnabled(-1, 1);
+
     // Hide cursor and draw initial items
     out.write("\x1b[?25l");
     renderItems();
@@ -280,20 +296,6 @@ export function interactiveMenu(
     if (stdin.setRawMode) stdin.setRawMode(true);
     stdin.resume();
     stdin.setEncoding("utf-8");
-
-    // Skip over disabled items when navigating
-    function nextEnabled(from: number, dir: 1 | -1): number {
-      let i = (from + dir + items.length) % items.length;
-      let attempts = 0;
-      while (items[i]!.disabled && attempts < items.length) {
-        i = (i + dir + items.length) % items.length;
-        attempts++;
-      }
-      return i;
-    }
-
-    // Start cursor on first enabled item
-    selected = nextEnabled(-1, 1);
 
     function onData(key: string) {
       if (key === "\x1b[A" || key === "k") {


### PR DESCRIPTION
Closes #55.

## Summary

- **SYN_INSTALL_DIR written as absolute path** — `path.resolve()` is applied to the install dir in `InitFlow` (covers both the default and any `--dir` flag). The resolved path is written to `.env` so `SYN_WORKSPACE_HOST_DIR` is always absolute for Docker bind mounts. Two new integration tests verify the invariant, including a relative `--dir` edge case.

- **Pre-init menu routes: hard-exit replaced with inline UX** — `MenuItem` extended with `disabled` and `disabledReason`. `showMenu` checks whether the install dir exists and marks the 8 post-init commands as disabled. Disabled items render dimmed with `✗`, the cursor skips over them, and pressing Enter shows an inline error banner and re-prompts instead of ejecting the user.

- **Credential rotation disabled safely** — single-phase rotation breaks the event store on stack restart (event store reads new secret, DB no longer accepts it). Rotation now shows a one-line warning with a link to #56 where the two-phase implementation is tracked. `credentials rollback` subcommand added: restores `.env` from `.env.backup` and restarts the stack, ready to activate when phase 2 re-enables rotation.

- **Docs** — README lifecycle section now includes `credentials`, file tree includes `.env.backup`.

## Test plan

- [ ] `npm test` — 86/86 passing
- [ ] `npm run build` — clean, no TypeScript errors
- [ ] Manual: run `node dist/cli.js` without `~/.syntropic137` present, verify post-init commands are dimmed and pressing Enter on one shows an inline error without exiting
- [ ] Manual: `node dist/cli.js init --skip-docker --skip-github`, verify `grep SYN_INSTALL_DIR .env` returns an absolute path
- [ ] Manual: `node dist/cli.js credentials rotate`, verify one-line warning with issue link
- [ ] Manual: `node dist/cli.js credentials rollback` with no backup, verify graceful "no backup found" message