### PR TITLE
fix(#60): detect Anthropic credential type by prefix and route to correct env var

### DIFF
--- a/src/cli.credentialRouting.test.ts
+++ b/src/cli.credentialRouting.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { routeAnthropicCredential } from "./cli.js";
+import { ENV_KEYS } from "./constants.js";
+
+describe("routeAnthropicCredential — npx#60", () => {
+  it("routes an OAuth token (sk-ant-oat01-…) to CLAUDE_CODE_OAUTH_TOKEN", () => {
+    const routed = routeAnthropicCredential("sk-ant-oat01-EXAMPLE-payload-here");
+    expect(routed).not.toBeNull();
+    expect(routed?.envKey).toBe(ENV_KEYS.CLAUDE_CODE_OAUTH_TOKEN);
+    expect(routed?.value).toBe("sk-ant-oat01-EXAMPLE-payload-here");
+  });
+
+  it("routes an API key (sk-ant-… without oat01) to ANTHROPIC_API_KEY", () => {
+    const routed = routeAnthropicCredential("sk-ant-api03-EXAMPLE-payload");
+    expect(routed).not.toBeNull();
+    expect(routed?.envKey).toBe(ENV_KEYS.ANTHROPIC_API_KEY);
+    expect(routed?.value).toBe("sk-ant-api03-EXAMPLE-payload");
+  });
+
+  it("trims surrounding whitespace before classifying", () => {
+    const routed = routeAnthropicCredential("   sk-ant-oat01-padded-with-spaces   ");
+    expect(routed?.envKey).toBe(ENV_KEYS.CLAUDE_CODE_OAUTH_TOKEN);
+    expect(routed?.value).toBe("sk-ant-oat01-padded-with-spaces");
+  });
+
+  it("rejects empty input", () => {
+    expect(routeAnthropicCredential("")).toBeNull();
+    expect(routeAnthropicCredential("   ")).toBeNull();
+  });
+
+  it("rejects values that do not start with sk-ant-", () => {
+    expect(routeAnthropicCredential("sk-OPENAI-anything")).toBeNull();
+    expect(routeAnthropicCredential("ghp_github_token")).toBeNull();
+    expect(routeAnthropicCredential("random-junk")).toBeNull();
+  });
+
+  it("does not split sk-ant-oat01- on substring match elsewhere in the string", () => {
+    // A pathological API key that happens to contain 'oat01' mid-string
+    // should still be classified as an API key, not an OAuth token.
+    const routed = routeAnthropicCredential("sk-ant-api-contains-oat01-mid");
+    expect(routed?.envKey).toBe(ENV_KEYS.ANTHROPIC_API_KEY);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -179,17 +179,36 @@ export class InitFlow {
       info("Found credentials in environment");
       envValues[ENV_KEYS.CLAUDE_CODE_OAUTH_TOKEN] = existingOauth;
     } else if (existingKey) {
-      info("Found ANTHROPIC_API_KEY in environment");
-      envValues[ENV_KEYS.ANTHROPIC_API_KEY] = existingKey;
-    } else {
-      info("Anthropic credentials are required to run agents.");
-      info("Enter your Anthropic API key, or set ANTHROPIC_API_KEY in your environment.");
-      info("Get a key at: https://console.anthropic.com/settings/keys");
-      const apiKey = await promptSecret(ENV_KEYS.ANTHROPIC_API_KEY);
-      if (apiKey) {
-        envValues[ENV_KEYS.ANTHROPIC_API_KEY] = apiKey;
+      // Prefix-detect what was actually exported. A user who exported their
+      // Anthropic credential as ANTHROPIC_API_KEY may have pasted any token
+      // type into that variable; route it to the correct field by prefix.
+      const routed = routeAnthropicCredential(existingKey);
+      if (routed) {
+        info("Found credentials in environment");
+        envValues[routed.envKey] = routed.value;
       } else {
-        warn("No API key provided. You can add it to .env later.");
+        warn("ANTHROPIC_API_KEY in environment does not look like a valid Anthropic credential; ignoring.");
+      }
+    } else {
+      // Neutral prompt copy: do not name the credential type. Accept whatever
+      // the user pastes, then prefix-detect to route it to the correct env
+      // var. See ADR-024 (platform repo) for why this matters: Claude Code CLI
+      // requires the credential under the matching env var name; routing it
+      // to the wrong field silently breaks every workflow run.
+      info("Anthropic credentials are required to run agents.");
+      info("Paste your Anthropic credential below.");
+      info("Get a credential at: https://console.anthropic.com/settings/keys");
+      const credential = await promptSecret("ANTHROPIC_CREDENTIAL");
+      if (!credential) {
+        warn("No credential provided. You can add it to .env later.");
+      } else {
+        const routed = routeAnthropicCredential(credential);
+        if (routed) {
+          envValues[routed.envKey] = routed.value;
+          info(`Credential stored as ${routed.envKey}.`);
+        } else {
+          warn("Credential does not look like a valid Anthropic token (expected sk-ant-… prefix). Skipping; you can add it to .env manually later.");
+        }
       }
     }
 
@@ -930,6 +949,41 @@ ${usageLines}
     }
     return dir;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic credential routing
+// ---------------------------------------------------------------------------
+
+/**
+ * Route a pasted Anthropic credential to the correct env var by prefix.
+ *
+ * Claude Code CLI requires the credential under a specific env var matching
+ * its type. Pasting an OAuth token into ANTHROPIC_API_KEY (or vice versa)
+ * silently breaks every workflow run because the platform reads each var
+ * independently and the CLI rejects mismatched types at its local format
+ * check.
+ *
+ * Returns null if the token does not look like a recognised Anthropic
+ * credential. The caller is responsible for messaging that to the user.
+ *
+ * Notes on the prefix table (current as of 2026-05):
+ *   sk-ant-oat01-…  Claude Code OAuth token from `claude setup-token`
+ *   sk-ant-…        Anthropic API key from console.anthropic.com (anything
+ *                   else with the sk-ant- prefix that isn't oat01)
+ */
+export function routeAnthropicCredential(
+  raw: string,
+): { envKey: string; value: string } | null {
+  const value = raw.trim();
+  if (!value) return null;
+  if (value.startsWith("sk-ant-oat01-")) {
+    return { envKey: ENV_KEYS.CLAUDE_CODE_OAUTH_TOKEN, value };
+  }
+  if (value.startsWith("sk-ant-")) {
+    return { envKey: ENV_KEYS.ANTHROPIC_API_KEY, value };
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -175,20 +175,28 @@ export class InitFlow {
     const existingKey = process.env.ANTHROPIC_API_KEY || "";
     const existingOauth = process.env.CLAUDE_CODE_OAUTH_TOKEN || "";
 
+    // Try to use what's already in the environment first. If found but malformed,
+    // warn AND fall through to the interactive prompt so the user can correct it
+    // during init rather than ending with no credential at all.
+    let routedFromEnv: { envKey: string; value: string } | null = null;
     if (existingOauth) {
-      info("Found credentials in environment");
-      envValues[ENV_KEYS.CLAUDE_CODE_OAUTH_TOKEN] = existingOauth;
+      routedFromEnv = routeAnthropicCredential(existingOauth);
+      if (!routedFromEnv) {
+        warn("CLAUDE_CODE_OAUTH_TOKEN in environment does not look like a valid Anthropic credential; will prompt instead.");
+      }
     } else if (existingKey) {
       // Prefix-detect what was actually exported. A user who exported their
       // Anthropic credential as ANTHROPIC_API_KEY may have pasted any token
       // type into that variable; route it to the correct field by prefix.
-      const routed = routeAnthropicCredential(existingKey);
-      if (routed) {
-        info("Found credentials in environment");
-        envValues[routed.envKey] = routed.value;
-      } else {
-        warn("ANTHROPIC_API_KEY in environment does not look like a valid Anthropic credential; ignoring.");
+      routedFromEnv = routeAnthropicCredential(existingKey);
+      if (!routedFromEnv) {
+        warn("ANTHROPIC_API_KEY in environment does not look like a valid Anthropic credential; will prompt instead.");
       }
+    }
+
+    if (routedFromEnv) {
+      info("Found credentials in environment");
+      envValues[routedFromEnv.envKey] = routedFromEnv.value;
     } else {
       // Neutral prompt copy: do not name the credential type. Accept whatever
       // the user pastes, then prefix-detect to route it to the correct env
@@ -198,7 +206,8 @@ export class InitFlow {
       info("Anthropic credentials are required to run agents.");
       info("Paste your Anthropic credential below.");
       info("Get a credential at: https://console.anthropic.com/settings/keys");
-      const credential = await promptSecret("ANTHROPIC_CREDENTIAL");
+      const raw = await promptSecret("Anthropic credential");
+      const credential = raw.trim();
       if (!credential) {
         warn("No credential provided. You can add it to .env later.");
       } else {


### PR DESCRIPTION
Closes #60.

## Problem

The init wizard prompts for "Anthropic API key" and writes whatever the user pastes into `ANTHROPIC_API_KEY=`. Claude Max subscribers don't have an API key — they have an OAuth token from `claude setup-token` (`sk-ant-oat01-…`). Pasting that into `ANTHROPIC_API_KEY` silently breaks every workflow run because:

- The platform reads `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` independently
- Claude Code CLI does a local format check (`sk-ant-oat01-…` for OAuth, `sk-ant-…` for API key) and rejects mismatched types before any HTTP call
- Result: `Not logged in · Please run /login` on every workflow, no error message hinting at the misconfigured field

This was the actual root cause that took ~2 hours to diagnose during cycle-001 dogfood (the user's Mac mini had an OAT sitting in `ANTHROPIC_API_KEY=` since first npx install months ago).

## Fix

Adds `routeAnthropicCredential()` which classifies a pasted token by prefix:

| Prefix | Routed to |
|---|---|
| `sk-ant-oat01-…` | `CLAUDE_CODE_OAUTH_TOKEN` |
| `sk-ant-…` (without `oat01`) | `ANTHROPIC_API_KEY` |
| anything else | rejected with a clear warning |

The prompt copy is now neutral ("Paste your Anthropic credential") and does not name OAuth tokens — Anthropic's ToS treats third-party tools prompting for OAuth tokens by name as a gray area. The wizard accepts whatever the user has and routes it correctly.

The same routing logic also runs when `ANTHROPIC_API_KEY` is found in the environment at startup — if it actually contains an OAT, it's routed to the correct env var so the `.env` ends up correct regardless of which env var the operator exported.

## Validation

```bash
pnpm run init -- --skip-docker --skip-github --dir /tmp/syn137-npx-test
# Paste real OAT (sk-ant-oat01-…) at the credential prompt
grep '^CLAUDE_CODE_OAUTH_TOKEN\|^ANTHROPIC_API_KEY' /tmp/syn137-npx-test/.env
# Observed:
#   ANTHROPIC_API_KEY=
#   CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-…
```

92 tests pass (8 files), including 6 new unit tests covering OAuth routing, API-key routing, whitespace trimming, empty input, non-Anthropic input, and the substring-match edge case (an API key that happens to contain `oat01` mid-string).

## Companion changes

This is the third leg of the EOD self-host trio:

- syntropic137 [PR #722](https://github.com/syntropic137/syntropic137/pull/722) — platform reads `settings.claude_code_oauth_token` and injects the real value into agent env (was injecting the literal `"proxy-managed"` placeholder)
- syntropic137 [PR #727](https://github.com/syntropic137/syntropic137/pull/727) — `IMAGES=1` on docker-socket-proxy so first-run workspace image pull self-heals
- this PR — credentials land in the correct `.env` field so the platform's read path actually works

Together: fresh user runs `npx syntropic137 init`, pastes any working Anthropic credential, runs a workflow, it works. No SSH, no manual `.env` edits.

## Test plan

- [x] Unit tests for routing helper (6 new cases)
- [x] All existing tests still pass (92 total)
- [x] Manual init validated locally — OAT routes to correct env var
- [ ] Reviewer validates the API-key path: paste a `sk-ant-api…` key, observe `ANTHROPIC_API_KEY=<value>` and `CLAUDE_CODE_OAUTH_TOKEN=` (empty)
- [ ] Reviewer validates the rejection path: paste garbage, observe warning + neither field set